### PR TITLE
Tweak values to account for osu-web updates

### DIFF
--- a/src/Bot.cpp
+++ b/src/Bot.cpp
@@ -237,7 +237,13 @@ void Bot::start()
             {
                 message.embeds.push_back(m_thirdRangeEmbed);
             }
-            m_bot.message_edit(message);
+            m_bot.message_edit(message, [buttonID](const dpp::confirmation_callback_t& callback)
+            {
+                if (callback.is_error())
+                {
+                    LOG_WARN("Failed to edit message after button ", buttonID, " was pressed; ", callback.get_error().message);
+                }
+            });
             event.reply();
         }
     });
@@ -406,7 +412,7 @@ dpp::embed Bot::createScrapePlayersEmbed(RankRange rankRange, nlohmann::json jso
 
     // Add static embed fields
     int hour = DosuConfig::scrapePlayersRunHour;
-    std::string footerText = "Runs every day at " + Detail::toHourString(hour) + "PST";
+    std::string footerText = "Runs every day at " + Detail::toHourString(hour) + "PST"; // FIXME: UTC
     std::string footerIcon = k_twemojiClockPrefix + Detail::toHexString(Detail::convertTo12Hour(hour) - 1) + k_twemojiClockSuffix;
     dpp::embed embed = dpp::embed()
         .set_author("Here's your daily dose of osu!", "https://github.com/mbalsdon/daily-dosu", k_iconImgUrl) // zesty ahh bot

--- a/src/DosuConfig.cpp
+++ b/src/DosuConfig.cpp
@@ -7,6 +7,9 @@
 #include <fstream>
 #include <filesystem>
 #include <iostream>
+#include <chrono>
+#include <ctime>
+
 
 int DosuConfig::logLevel;
 std::string DosuConfig::discordBotToken;
@@ -15,6 +18,40 @@ std::string DosuConfig::osuClientSecret;
 int DosuConfig::osuApiCooldownMs;
 int DosuConfig::scrapePlayersRunHour;
 int DosuConfig::backupServerConfigRunHour;
+
+namespace Detail
+{
+int utcToLocal(int utcHour)
+{
+    auto now = std::chrono::system_clock::now();
+    auto nowTt = std::chrono::system_clock::to_time_t(now);
+
+    std::tm localTm = *std::localtime(&nowTt);
+    std::tm utcTm = *std::gmtime(&nowTt);
+
+    int offset = localTm.tm_hour - utcTm.tm_hour;
+    if (offset > 12)
+    {
+        offset -= 24;
+    }
+    else if (offset < -12)
+    {
+        offset += 24;
+    }
+
+    int localHour = utcHour + offset;
+    if (localHour >= 24)
+    {
+        localHour -= 24;
+    }
+    else if (localHour < 0)
+    {
+        localHour += 24;
+    }
+
+    return localHour;
+}
+}
 
 /**
  * Load JSON configuration.
@@ -80,8 +117,8 @@ void DosuConfig::setupConfig()
     nlohmann::json newConfigJson;
     newConfigJson[k_logLevelKey] = 1;
     newConfigJson[k_osuApiCooldownMsKey] = 1000;
-    newConfigJson[k_scrapePlayersRunHourKey] = 0;
     newConfigJson[k_backupServerConfigRunHourKey] = 23;
+    newConfigJson[k_scrapePlayersRunHourKey] = Detail::utcToLocal(6);
 
     std::string botToken;
     std::string clientID;

--- a/src/OsuWrapper.cpp
+++ b/src/OsuWrapper.cpp
@@ -241,8 +241,8 @@ bool OsuWrapper::getUser(UserID userID, DosuUser& user)
         user.username = responseDataJson.at("username").get<Username>();
         user.countryCode = responseDataJson.at("country_code").get<CountryCode>();
         user.pfpLink = responseDataJson.at("avatar_url").get<ProfilePicture>();
-        user.currentRank = responseDataJson.at("rank_history").at("data")[89].get<Rank>();
-        user.yesterdayRank = responseDataJson.at("rank_history").at("data")[88].get<Rank>();
+        user.currentRank = responseDataJson.at("rank_history").at("data")[88].get<Rank>();
+        user.yesterdayRank = responseDataJson.at("rank_history").at("data")[87].get<Rank>();
         user.hoursPlayed = responseDataJson.at("statistics").at("play_time").get<uint64_t>() / 3600; // FIXME: round insteead of truncate
         user.performancePoints = responseDataJson.at("statistics").at("pp").get<PerformancePoints>();
         user.accuracy = responseDataJson.at("statistics").at("hit_accuracy").get<Accuracy>();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -53,10 +53,18 @@ int main(int argc, char const *argv[])
     return 0;
 }
 
-// FUTURE: parallelize scrapeplayers if necessary
-
 // FUTURE: new job: highest play today
 // // https://github.com/Ameobea/osutrack-api
 // // "Get the best plays by pp for all users in a given mode"
 
 // FUTURE: move to sqlite3 you chud
+
+// FUTURE: country
+
+// FUTURE: parallelize scrapeplayers
+// // how does osu-web update rank history
+
+// FUTURE: bot makerequest if necessary
+// // takes fn as param
+// // spawn thread for fn param s.t. each req is executing/retrying concurrently
+// // on err (5xx), thread yield if delay time (exponential backoff) hasn't passed


### PR DESCRIPTION
- currentRank now points to yesterday, yesterdayRank now points to 2 days ago
- Set default dosu_config scrape run hour to 0600 UTC (osu-web seems to update ~0545?)
- Also add skeleton error handling to button presses