### PR TITLE
Clean up user-facing logic

### DIFF
--- a/include/Bot.h
+++ b/include/Bot.h
@@ -15,7 +15,7 @@
 #include <atomic>
 
 const std::chrono::seconds k_cmdRateLimitPeriod = std::chrono::seconds(5);
-const std::chrono::seconds k_buttonRateLimitPeriod = std::chrono::seconds(3);
+const std::chrono::seconds k_interactionRateLimitPeriod = std::chrono::seconds(3);
 
 /**
  * DPP wrapper for the Discord bot. All event handling logic (and nothing else) should go here.
@@ -61,6 +61,7 @@ private:
     std::atomic<bool> m_bIsInitialized;
 
     std::unordered_map<dpp::snowflake, std::chrono::steady_clock::time_point> m_latestCommands;
+    std::unordered_map<dpp::snowflake, std::chrono::steady_clock::time_point> m_latestInteractions;
 
     dpp::embed m_helpEmbed;
 

--- a/include/BotConfigDatabaseManager.h
+++ b/include/BotConfigDatabaseManager.h
@@ -28,6 +28,7 @@ public:
     std::vector<dpp::snowflake> getChannelIDs();
     void addChannel(dpp::snowflake channelID);
     void removeChannel(dpp::snowflake channelID);
+    bool channelExists(dpp::snowflake channelID);
 
 private:
     BotConfigDatabaseManager()

--- a/src/BotConfigDatabaseManager.cpp
+++ b/src/BotConfigDatabaseManager.cpp
@@ -103,6 +103,19 @@ void BotConfigDatabaseManager::removeChannel(dpp::snowflake channelID)
 }
 
 /**
+ * Check if channel exists.
+ */
+bool BotConfigDatabaseManager::channelExists(dpp::snowflake channelID)
+{
+    std::lock_guard<std::mutex> lock(m_dbMtx);
+    LOG_DEBUG("Checking if channel exists with ID ", channelID.operator uint64_t());
+
+    SQLite::Statement query(*m_database, "SELECT COUNT(*) FROM BotConfig WHERE channelID = ?");
+    query.bind(1, static_cast<int64_t>(channelID.operator uint64_t()));
+    return (query.executeStep() && query.getColumn(0).getInt64() > 0);
+}
+
+/**
  * BotConfigDatabaseManager destructor.
  */
 BotConfigDatabaseManager::~BotConfigDatabaseManager()


### PR DESCRIPTION
- Alert user about access/perms issues
- Separate command/interaction ratelimits
- Add "already enabled/disabled" messaging to subscribe/unsubscribe commands