### PR TITLE
Add filter-by-country support to scrapeRankings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.16)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 set(PROJECT_NAME "daily-dosu")
+set(CMAKE_BUILD_TYPE Debug)
 
 project(${PROJECT_NAME})
 set(SOURCES

--- a/README.md
+++ b/README.md
@@ -24,9 +24,10 @@ I have only tested on Linux. If you try running on other platforms, let me know 
 2. After cloning the repository, initialize submodules:
     - `git submodule update --init --recursive`
 3. Configure the project:
-    - `mkdir <build folder path> && cd <build folder path> && cmake <daily-dosu path>`
+    - `mkdir <build folder path> && cd <build folder path>`
+    - `cmake <daily-dosu path> -DCMAKE_BUILD_TYPE=Release`
 4. Compile and run the project:
-    - `` make -j`nproc` ``
+    - `` cmake --build . -j`nproc` ``
     - `./daily-dosu`
 
 

--- a/TODO.txt
+++ b/TODO.txt
@@ -1,7 +1,13 @@
 - TODO
---- country
------ check what get rankings endpoint does with "country" param
------ how to format this with new jobs in mind (look thru supported components)
+--- improve country input
+----- store alpha2, alpha3, and full name; maps to alpha2; match against it in modal
+----- if unrecognized, direct the user to a help command; dms them all countries directly
+----- rmbr to update modal desc
+
+--- other modes support
+--- clean up metadata functions (use iterator or sth)
+--- filter by playstyle ferda?
+--- update to cpp20, update libraries (dpp making valgrind cry)
 
 - MAYBE
 --- new jobs

--- a/include/Bot.h
+++ b/include/Bot.h
@@ -42,6 +42,10 @@ private:
     void onReady(const dpp::ready_t& event);
     void onSlashCommand(const dpp::slashcommand_t& event);
     void onButtonClick(const dpp::button_click_t& event);
+    void onFormSubmit(const dpp::form_submit_t& event);
+
+    void onCompletion(const dpp::confirmation_callback_t& callback, const std::string customID);
+    void onCompletionReply(const dpp::confirmation_callback_t& callback, const std::string customID, const dpp::interaction_create_t event);
 
     void deleteGlobalCommand(std::string cmdName);
 
@@ -51,8 +55,8 @@ private:
     void cmdSubscribe(const dpp::slashcommand_t& event);
     void cmdUnsubscribe(const dpp::slashcommand_t& event);
 
-    void buildHelpEmbeds();
-    bool buildScrapeRankingsEmbeds();
+    void buildStaticComponents();
+    bool buildNewsletter(const std::string countryCode, const RankRange rankRange, dpp::message& message);
 
     dpp::cluster m_bot;
     RankingsDatabaseManager& m_rankingsDbm;
@@ -64,12 +68,8 @@ private:
     std::unordered_map<dpp::snowflake, std::chrono::steady_clock::time_point> m_latestInteractions;
 
     dpp::embed m_helpEmbed;
-
-    dpp::embed m_scrapeRankingsFirstRangeEmbed;
-    dpp::embed m_scrapeRankingsSecondRangeEmbed;
-    dpp::embed m_scrapeRankingsThirdRangeEmbed;
-    dpp::component m_scrapeRankingsActionRow;
-    bool m_bScrapeRankingsEmbedsPopulated;
+    dpp::component m_scrapeRankingsActionRow1;
+    dpp::component m_scrapeRankingsActionRow2;
 };
 
 #endif /* __BOT_H__ */

--- a/include/EmbedGenerator.h
+++ b/include/EmbedGenerator.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <vector>
 #include <sstream>
+#include <string>
 
 const std::string k_twemojiClockPrefix = "https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f55";
 const std::string k_twemojiClockSuffix = ".png";
@@ -29,13 +30,16 @@ public:
     ~EmbedGenerator() = default;
 
     dpp::embed helpEmbed();
-    dpp::embed scrapeRankingsEmbed(RankRange rankRange, std::vector<RankImprovement> top, std::vector<RankImprovement> bottom);
+    dpp::embed scrapeRankingsEmbed(const std::string countryCode, const RankRange rankRange, std::vector<RankImprovement> top, std::vector<RankImprovement> bottom);
 
-    dpp::component scrapeRankingsActionRow();
+    dpp::component scrapeRankingsActionRow1();
+    dpp::component scrapeRankingsActionRow2();
+    dpp::interaction_modal_response scrapeRankingsFilterCountryModal();
+    bool parseMetadata(const dpp::message message, EmbedMetadata& metadata);
 
 private:
-    void addPlayersToScrapeRankingsDescription(std::stringstream& description, std::vector<RankImprovement> players, bool bIsTop);
-    ProfilePicture scrapeRankingsThumbnail(std::vector<RankImprovement> top, std::vector<RankImprovement> bottom);
+    std::string metadataTag(const std::string countryCode, const RankRange rankRange);
+    void addPlayersToScrapeRankingsDescription(std::stringstream& description, std::vector<RankImprovement> players, const bool bIsTop);
 };
 
 #endif /* __EMBED_GENERATOR_H__ */

--- a/include/RankingsDatabaseManager.h
+++ b/include/RankingsDatabaseManager.h
@@ -36,8 +36,8 @@ public:
     std::vector<UserID> getUserIDsWithNullYesterdayRank();
     void updateYesterdayRanks(std::vector<std::pair<UserID, Rank>>& userYesterdayRanks);
     bool isRankingsEmpty();
-    std::vector<RankImprovement> getTopRankImprovements(int64_t minRank, int64_t maxRank, std::size_t numUsers);
-    std::vector<RankImprovement> getBottomRankImprovements(int64_t minRank, int64_t maxRank, std::size_t numUsers);
+    std::vector<RankImprovement> getTopRankImprovements(std::string countryCode, int64_t minRank, int64_t maxRank, std::size_t numUsers);
+    std::vector<RankImprovement> getBottomRankImprovements(std::string countryCode, int64_t minRank, int64_t maxRank, std::size_t numUsers);
 
 private:
     RankingsDatabaseManager()

--- a/include/Util.h
+++ b/include/Util.h
@@ -6,6 +6,48 @@
 #include <cstdint>
 #include <filesystem>
 #include <chrono>
+#include <array>
+#include <string_view>
+#include <utility>
+#include <algorithm>
+
+/* - - - - - - Constants - - - - - - - */
+
+static constexpr std::size_t k_getRankingIDMaxNumIDs = 50;
+static constexpr std::size_t k_getRankingIDMaxPage = 200;
+
+static constexpr std::size_t k_numDisplayUsersTop = 15;
+static constexpr std::size_t k_numDisplayUsersBottom = 5;
+const std::size_t k_numDisplayUsers = std::max(k_numDisplayUsersTop, k_numDisplayUsersBottom);
+
+const std::chrono::hours k_minValidScrapeRankingsHour = std::chrono::hours(22);
+const std::chrono::hours k_maxValidScrapeRankingsHour = std::chrono::hours(26);
+
+const std::filesystem::path k_rootDir = std::filesystem::path(__FILE__).parent_path().parent_path();
+const std::filesystem::path k_dosuConfigFilePath = k_rootDir / "dosu_config.json";
+const std::filesystem::path k_dataDir = k_rootDir / "data";
+
+const std::string k_cmdHelp = "help";
+const std::string k_cmdPing = "ping";
+const std::string k_cmdNewsletter = "newsletter";
+const std::string k_cmdSubscribe = "subscribe";
+const std::string k_cmdUnsubscribe = "unsubscribe";
+
+const std::string k_cmdHelpDesc = "List the bot's commands.";
+const std::string k_cmdPingDesc = "Check if the bot is alive.";
+const std::string k_cmdNewsletterDesc = "Display the daily newsletter.";
+const std::string k_cmdSubscribeDesc = "Enable daily newsletters for this channel.";
+const std::string k_cmdUnsubscribeDesc = "Disable daily newsletters for this channel.";
+
+const std::string k_firstRangeButtonID = "first_range_button";
+const std::string k_secondRangeButtonID = "second_range_button";
+const std::string k_thirdRangeButtonID = "third_range_button";
+const std::string k_filterCountryButtonID = "filter_country_button";
+const std::string k_clearFiltersButtonID = "clear_filters_button";
+const std::string k_filterCountryModalID = "filter_country_modal";
+const std::string k_filterCountryTextInputID = "filter_country_text_input";
+
+const std::string k_global = "GLOBAL";
 
 /* - - - - - - - - Types - - - - - - - */
 
@@ -54,46 +96,78 @@ struct RankImprovement
     double relativeImprovement;
 };
 
-enum class RankRange
+struct ISO3166_Alpha2
 {
-    First,
-    Second,
-    Third
+    static constexpr std::array<std::string_view, 249> codes = { // weeeeee
+        "AF", "AX", "AL", "DZ", "AS", "AD", "AO", "AI", "AQ", "AG", "AR", "AM", "AW", "AU", "AT", "AZ", "BS", "BH", "BD", "BB", "BY", "BE", "BZ", "BJ", "BM", "BT", "BO", "BQ", "BA", "BW", "BV", "BR", "IO", "BN", "BG", "BF", "BI", "KH", "CM", "CA", "CV", "KY", "CF", "TD", "CL", "CN", "CX", "CC", "CO", "KM", "CG", "CD", "CK", "CR", "CI", "HR", "CU", "CW", "CY", "CZ", "DK", "DJ", "DM", "DO", "EC", "EG", "SV", "GQ", "ER", "EE", "ET", "FK", "FO", "FJ", "FI", "FR", "GF", "PF", "TF", "GA", "GM", "GE", "DE", "GH", "GI", "GR", "GL", "GD", "GP", "GU", "GT", "GG", "GN", "GW", "GY", "HT", "HM", "VA", "HN", "HK", "HU", "IS", "IN", "ID", "IR", "IQ", "IE", "IM", "IL", "IT", "JM", "JP", "JE", "JO", "KZ", "KE", "KI", "KP", "KR", "KW", "KG", "LA", "LV", "LB", "LS", "LR", "LY", "LI", "LT", "LU", "MO", "MK", "MG", "MW", "MY", "MV", "ML", "MT", "MH", "MQ", "MR", "MU", "YT", "MX", "FM", "MD", "MC", "MN", "ME", "MS", "MA", "MZ", "MM", "NA", "NR", "NP", "NL", "NC", "NZ", "NI", "NE", "NG", "NU", "NF", "MP", "NO", "OM", "PK", "PW", "PS", "PA", "PG", "PY", "PE", "PH", "PN", "PL", "PT", "PR", "QA", "RE", "RO", "RU", "RW", "BL", "SH", "KN", "LC", "MF", "PM", "VC", "WS", "SM", "ST", "SA", "SN", "RS", "SC", "SL", "SG", "SX", "SK", "SI", "SB", "SO", "ZA", "GS", "SS", "ES", "LK", "SD", "SR", "SJ", "SZ", "SE", "CH", "SY", "TW", "TJ", "TZ", "TH", "TL", "TG", "TK", "TO", "TT", "TN", "TR", "TM", "TC", "TV", "UG", "UA", "AE", "GB", "US", "UM", "UY", "UZ", "VU", "VE", "VN", "VG", "VI", "WF", "EH", "YE", "ZM", "ZW"
+    };
 };
 
-/* - - - - - - Constants - - - - - - - */
 
-constexpr std::size_t k_getRankingIDMaxNumIDs = 50;
-constexpr std::size_t k_getRankingIDMaxPage = 200;
 
-constexpr std::size_t k_firstRangeMax = 100;
-constexpr std::size_t k_secondRangeMax = 1000;
-constexpr std::size_t k_thirdRangeMax = 10000;
+class RankRange
+{
+public:
+    enum Value
+    {
+        First,
+        Second,
+        Third
+    };
 
-constexpr std::size_t k_numDisplayUsersTop = 15;
-constexpr std::size_t k_numDisplayUsersBottom = 5;
+    RankRange() : m_value(Value::First) {}
+    RankRange(Value v) : m_value(v) {}
+    RankRange(int i) : m_value(static_cast<Value>(i)) {}
+    RankRange(std::string s) : m_value(static_cast<Value>(std::stoi(s))) {}
 
-const std::chrono::hours k_minValidScrapeRankingsHour = std::chrono::hours(22);
-const std::chrono::hours k_maxValidScrapeRankingsHour = std::chrono::hours(26);
+    bool operator==(const RankRange& other) const { return m_value == other.m_value; }
+    bool operator==(Value v) const { return m_value == v; }
 
-const std::filesystem::path k_rootDir = std::filesystem::path(__FILE__).parent_path().parent_path();
-const std::filesystem::path k_dosuConfigFilePath = k_rootDir / "dosu_config.json";
-const std::filesystem::path k_dataDir = k_rootDir / "data";
+    std::string toString() const
+    {
+        switch (m_value)
+        {
+        case Value::First: return "First";
+        case Value::Second: return "Second";
+        case Value::Third: return "Third";
+        default: return "Unknown";
+        }
+    }
 
-const std::string k_cmdHelp = "help";
-const std::string k_cmdPing = "ping";
-const std::string k_cmdNewsletter = "newsletter";
-const std::string k_cmdSubscribe = "subscribe";
-const std::string k_cmdUnsubscribe = "unsubscribe";
+    int toInt() const
+    {
+        return static_cast<int>(m_value);
+    }
 
-const std::string k_cmdHelpDesc = "List the bot's commands.";
-const std::string k_cmdPingDesc = "Check if the bot is alive.";
-const std::string k_cmdNewsletterDesc = "Display the daily newsletter.";
-const std::string k_cmdSubscribeDesc = "Enable daily newsletters for this channel.";
-const std::string k_cmdUnsubscribeDesc = "Disable daily newsletters for this channel.";
+    std::pair<int64_t, int64_t> toRange() const
+    {
+        switch (m_value)
+        {
+        case Value::First: return std::make_pair(1, 100);
+        case Value::Second: return std::make_pair(101, 1000);
+        case Value::Third: return std::make_pair(1001, 10000);
+        default: return std::make_pair(0, 10000);
+        }
+    }
 
-const std::string k_firstRangeButtonID = "first_range_button";
-const std::string k_secondRangeButtonID = "second_range_button";
-const std::string k_thirdRangeButtonID = "third_range_button";
+    Value m_value;
+};
+
+class EmbedMetadata
+{
+public:
+    EmbedMetadata()
+    : m_countryCode(k_global)
+    , m_rankRange(RankRange())
+    {}
+
+    EmbedMetadata(std::string countryCode, RankRange rankRange)
+    : m_countryCode(countryCode)
+    , m_rankRange(rankRange)
+    {}
+
+    std::string m_countryCode;
+    RankRange m_rankRange;
+};
 
 #endif /* __UTIL_H__ */

--- a/src/DailyJob.cpp
+++ b/src/DailyJob.cpp
@@ -121,7 +121,6 @@ void DailyJob::runJobLoop()
         {
             LOG_ERROR("Unknown error in job ", m_name);
         }
-        
     }
 }
 

--- a/src/RankingsDatabaseManager.cpp
+++ b/src/RankingsDatabaseManager.cpp
@@ -197,8 +197,9 @@ bool RankingsDatabaseManager::isRankingsEmpty()
 
 /**
  * Get top users sorted by relative rank improvement.
+ * Entering "GLOBAL" for countryCode means no filter.
  */
-std::vector<RankImprovement> RankingsDatabaseManager::getTopRankImprovements(int64_t minRank, int64_t maxRank, std::size_t numUsers)
+std::vector<RankImprovement> RankingsDatabaseManager::getTopRankImprovements(std::string countryCode, int64_t minRank, int64_t maxRank, std::size_t numUsers)
 {
     std::lock_guard<std::mutex> lock(m_dbMtx);
     LOG_DEBUG("Retrieving top users by rank improvement...");
@@ -226,6 +227,7 @@ std::vector<RankImprovement> RankingsDatabaseManager::getTopRankImprovements(int
             AND currentRank >= ?
             AND currentRank <= ?
             AND yesterdayRank > currentRank
+            AND (countryCode = ? OR ? = 'GLOBAL')
         ORDER BY 
             (CAST(yesterdayRank - currentRank AS FLOAT) / currentRank) DESC
         LIMIT ?
@@ -233,7 +235,9 @@ std::vector<RankImprovement> RankingsDatabaseManager::getTopRankImprovements(int
 
     query.bind(1, minRank);
     query.bind(2, maxRank);
-    query.bind(3, static_cast<int64_t>(numUsers));
+    query.bind(3, countryCode);
+    query.bind(4, countryCode);
+    query.bind(5, static_cast<int64_t>(numUsers));
 
     while (query.executeStep())
     {
@@ -257,8 +261,9 @@ std::vector<RankImprovement> RankingsDatabaseManager::getTopRankImprovements(int
 
 /**
  * Get bottom users sorted by relative rank improvement.
+ * Entering "GLOBAL" for countryCode means no filter.
  */
-std::vector<RankImprovement> RankingsDatabaseManager::getBottomRankImprovements(int64_t minRank, int64_t maxRank, std::size_t numUsers)
+std::vector<RankImprovement> RankingsDatabaseManager::getBottomRankImprovements(std::string countryCode, int64_t minRank, int64_t maxRank, std::size_t numUsers)
 {
     std::lock_guard<std::mutex> lock(m_dbMtx);
     LOG_DEBUG("Retrieving bottom users by rank improvement...");
@@ -285,6 +290,7 @@ std::vector<RankImprovement> RankingsDatabaseManager::getBottomRankImprovements(
             AND currentRank >= ?
             AND currentRank <= ?
             AND yesterdayRank < currentRank
+            AND (countryCode = ? OR ? = 'GLOBAL')
         ORDER BY 
             (CAST(currentRank - yesterdayRank AS FLOAT) / currentRank) DESC
         LIMIT ?
@@ -292,7 +298,9 @@ std::vector<RankImprovement> RankingsDatabaseManager::getBottomRankImprovements(
 
     query.bind(1, minRank);
     query.bind(2, maxRank);
-    query.bind(3, static_cast<int64_t>(numUsers));
+    query.bind(3, countryCode);
+    query.bind(4, countryCode);
+    query.bind(5, static_cast<int64_t>(numUsers));
 
     while (query.executeStep())
     {

--- a/src/ScrapeRankings.cpp
+++ b/src/ScrapeRankings.cpp
@@ -202,7 +202,6 @@ void scrapeRankings(RankingsDatabaseManager& rankingsDbm)
             endIdx += numLeftoverCalls;
         }
 
-        // FIXME: move chungus lambda to a function
         // Fire thread (each populates the vector with its portion)
         getUserThreads.emplace_back(
             Detail::processUsers,


### PR DESCRIPTION
- Embeds now store metadata used to track state
- No longer store embeds; everything now built on-demand
- Move RankRange types/consts into a (mostly) unified class
- Various minor refactors/cleanups